### PR TITLE
Update to allow websockets 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -54,12 +54,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -50,7 +50,7 @@ outputs:
         - requests >=2.26,<3
         - requests-toolbelt >=1.0.0,<2
         # websockets
-        - websockets >=10,<11
+        - websockets >=10,<12
         # boto
         - botocore >=1.21,<2
     test:


### PR DESCRIPTION
Reopening https://github.com/conda-forge/gql-feedstock/pull/18 now that gql 3.5 is released

https://github.com/graphql-python/gql/blob/v3.5.0/setup.py#L55

* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
